### PR TITLE
Fix/encoding detection

### DIFF
--- a/src/main/php/unittest/web/InputStream.class.php
+++ b/src/main/php/unittest/web/InputStream.class.php
@@ -1,0 +1,80 @@
+<?php namespace unittest\web;
+
+class InputStream extends \lang\Object implements \io\streams\InputStream {
+  const META_TAG = '<meta http-equiv="content-type" content="text/html; charset=%s">';
+
+  private $in, $head;
+
+  /**
+   * Creates a new input stream
+   *
+   * @param  peer.http.HttpResponse $response
+   */
+  public function __construct($response) {
+    $this->in= $response->getInputStream();
+
+    $charset= 'iso-8859-1'; // HTTP defines this as default!
+    if ($header= $response->header('Content-Type')) {
+      sscanf($header[0], '%[^;]; charset=%s', $contentType, $charset);
+    }
+    $this->embed($charset);
+  }
+
+  /**
+   * Embeds charset in head-section so that LibXML can pick it up during
+   * parsing. Unfortunately there is no way to tell DomDocument::loadHTML
+   * which charset the content is in other than this workaround.
+   *
+   * @param  string $charset
+   * @return void
+   */
+  private function embed($charset) {
+    $this->head= '';
+    while ($this->in->available()) {
+      $this->head.= $this->in->read();
+
+      if (preg_match('#\<meta\s+charset\s*=(.+)\>#i', $this->head, $matches)) {
+        $this->head= str_replace($matches[0], sprintf(self::META_TAG, trim($matches[1], ' "\'')), $this->head);
+        return;
+      } else if (preg_match('#\<(/head|body)\>#i', $this->head, $matches)) {
+        $this->head= str_replace($matches[0], sprintf(self::META_TAG, $charset).$matches[0], $this->head);
+        return;
+      }
+    }
+  }
+
+  /**
+   * Read a string
+   *
+   * @param   int limit default 8192
+   * @return  string
+   */
+  public function read($limit= 8192) {
+    if ($this->head) {
+      $chunk= substr($this->head, 0, $limit);
+      $this->head= substr($this->head, $limit);
+      return $chunk;
+    } else {
+      return $this->in->read($limit);
+    }
+  }
+
+  /**
+   * Returns the number of bytes that can be read from this stream 
+   * without blocking.
+   *
+   * @return int
+   */
+  public function available() {
+    return $this->head || $this->in->available();
+  }
+
+  /**
+   * Closes this input stream
+   *
+   * @return void
+   */
+  public function close() {
+    $this->in->close();
+  }
+}

--- a/src/main/php/unittest/web/WebTestCase.class.php
+++ b/src/main/php/unittest/web/WebTestCase.class.php
@@ -74,11 +74,10 @@ abstract class WebTestCase extends TestCase {
       // HHVM blocks all external resources by default, and the .ini setting
       // "hhvm.libxml.ext_entity_whitelist" cannot be set via ini_set().
       if (defined('HHVM_VERSION')) {
-        @$this->dom->loadHTML(Streams::readAll($this->response->getInputStream()));
+        @$this->dom->loadHTML(Streams::readAll(new InputStream($this->response)));
       } else {
-        @$this->dom->loadHTMLFile(Streams::readableUri($this->response->getInputStream()));
+        @$this->dom->loadHTMLFile(Streams::readableUri(new InputStream($this->response)));
       }
-      var_dump($this->dom->actualEncoding);
     }
     return $this->dom;
   }

--- a/src/test/php/unittest/web/tests/EncodingTest.class.php
+++ b/src/test/php/unittest/web/tests/EncodingTest.class.php
@@ -29,17 +29,20 @@ class EncodingTest extends WebTestCaseTest {
   /** @return var[][] */
   private function fixtures() {
     return [
-      [sprintf(self::$FIXTURE, '<meta charset="utf-8">')],
-      [sprintf(self::$FIXTURE, '<meta http-equiv="content-type" content="text/html; charset=utf-8">')],
-      [sprintf(utf8_decode(self::$FIXTURE), '<meta charset="iso-8859-1">')],
-      [sprintf(utf8_decode(self::$FIXTURE), '<meta http-equiv="content-type" content="text/html; charset=iso-8859-1">')],
-      [sprintf(self::$FIXTURE, '<!-- No meta tag -->')]
+      [[], sprintf(self::$FIXTURE, '<meta charset="utf-8">')],
+      [[], sprintf(self::$FIXTURE, '<meta http-equiv="content-type" content="text/html; charset=utf-8">')],
+      [[], sprintf(utf8_decode(self::$FIXTURE), '<meta charset="iso-8859-1">')],
+      [[], sprintf(utf8_decode(self::$FIXTURE), '<meta http-equiv="content-type" content="text/html; charset=iso-8859-1">')],
+      [[], sprintf(utf8_decode(self::$FIXTURE), '<!-- No meta tag -->')],
+      [['Content-Type: text/html; charset=utf-8'], sprintf(self::$FIXTURE, '<!-- No meta tag -->')],
+      [['Content-Type: text/html'], sprintf(utf8_decode(self::$FIXTURE), '<!-- No meta tag -->')],
+      [['Content-Type: text/html; charset=iso-8859-1'], sprintf(utf8_decode(self::$FIXTURE), '<!-- No meta tag -->')]
     ];
   }
 
   #[@test, @values('fixtures')]
-  public function title($fixture) {
-    $this->fixture->respondWith(HttpConstants::STATUS_OK, [], $fixture);
+  public function title($headers, $fixture) {
+    $this->fixture->respondWith(HttpConstants::STATUS_OK, $headers, $fixture);
     $this->fixture->beginAt('/');
     $this->fixture->assertTitleEquals('Über-Tests');
   }


### PR DESCRIPTION
Takes into account Content-Type header and meta charset=... which `DomDocument::loadHTML[File]()` does not / cannot.

Fixes issue #1
